### PR TITLE
feat: add a Docker Run task

### DIFF
--- a/src/main/java/io/kestra/plugin/docker/Run.java
+++ b/src/main/java/io/kestra/plugin/docker/Run.java
@@ -1,0 +1,101 @@
+package io.kestra.plugin.docker;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.tasks.*;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.scripts.exec.scripts.models.DockerOptions;
+import io.kestra.plugin.scripts.exec.scripts.models.RunnerType;
+import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
+import io.kestra.plugin.scripts.exec.scripts.runners.CommandsWrapper;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Run a Docker container"
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Run the docker/whalesay container with the commands 'cowsay hello'",
+            code = {"""
+                docker:
+                  image: docker/whalesay
+                  commands:
+                    - cowsay
+                    - hello"""
+            }
+        ),
+        @Example(
+            title = "Run the docker/whalesay container with no commands",
+            code = {"""
+                docker:
+                  image: docker/whalesay"""
+            }
+        )
+    }
+)
+public class Run extends Task implements RunnableTask<ScriptOutput>, NamespaceFilesInterface, InputFilesInterface, OutputFilesInterface {
+    @Schema(
+        title = "Docker options"
+    )
+    @PluginProperty
+    @NotNull
+    private DockerOptions docker;
+
+    @Schema(
+        title = "Additional environment variables for the Docker container."
+    )
+    @PluginProperty(
+        additionalProperties = String.class,
+        dynamic = true
+    )
+    protected Map<String, String> env;
+
+    @Builder.Default
+    @Schema(
+        title = "Whether to set the task state to `WARNING` if any `stdErr` is emitted."
+    )
+    @PluginProperty
+    protected Boolean warningOnStdErr = true;
+
+    private NamespaceFiles namespaceFiles;
+
+    private Object inputFiles;
+
+    private List<String> outputFiles;
+
+    @Schema(
+        title = "The commands to run"
+    )
+    @PluginProperty(dynamic = true)
+    @Builder.Default
+    private List<String> commands = Collections.emptyList();
+
+    @Override
+    public ScriptOutput run(RunContext runContext) throws Exception {
+        var commandWrapper = new CommandsWrapper(runContext)
+            .withEnv(this.getEnv())
+            .withWarningOnStdErr(this.getWarningOnStdErr())
+            .withRunnerType(RunnerType.DOCKER)
+            .withDockerOptions(this.docker)
+            .withNamespaceFiles(this.namespaceFiles)
+            .withInputFiles(this.inputFiles)
+            .withOutputFiles(this.outputFiles)
+            .withCommands(this.commands);
+        
+        return commandWrapper.run();
+    }
+}

--- a/src/test/java/io/kestra/plugin/docker/RunTest.java
+++ b/src/test/java/io/kestra/plugin/docker/RunTest.java
@@ -1,0 +1,39 @@
+package io.kestra.plugin.docker;
+
+import com.google.common.collect.ImmutableMap;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.TestsUtils;
+import io.kestra.plugin.scripts.exec.scripts.models.DockerOptions;
+import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+
+@MicronautTest
+class RunTest {
+    @Inject
+    RunContextFactory runContextFactory;
+
+    @Test
+    void run() throws Exception {
+        Run run = Run.builder()
+            .id("run")
+            .type(Run.class.getName())
+            .docker(DockerOptions.builder().image("docker/whalesay").build())
+            .commands(List.of("cowsay", "hello"))
+            .build();
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, run, ImmutableMap.of());
+
+        ScriptOutput output = run.run(runContext);
+
+        assertThat(output, notNullValue());
+        assertThat(output.getExitCode(), is(0));
+    }
+}


### PR DESCRIPTION
Fixes #8

It can be tested with this flow:

```
id: docker
namespace: company.team

tasks:
  - id: docker
    type: io.kestra.plugin.docker.Run
    docker:
      image: docker/whalesay
```

You can pass a list of commands:

```
id: docker
namespace: company.team

tasks:
  - id: docker
    type: io.kestra.plugin.docker.Run
    docker:
      image: docker/whalesay
    commands:
      - whalesay
      - hello
```

Note that is reuse our scripting facility so it is not needed to QA extensively the various docker properties, inout files, output files, namespace files as they are all already been tested. 