### PR TITLE
Added protocol property for docker push

### DIFF
--- a/src/main/java/io/kestra/plugin/docker/Build.java
+++ b/src/main/java/io/kestra/plugin/docker/Build.java
@@ -17,17 +17,14 @@ import io.kestra.core.utils.Rethrow;
 import io.kestra.plugin.scripts.runner.docker.Credentials;
 import io.kestra.plugin.scripts.runner.docker.DockerService;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import jakarta.validation.constraints.NotNull;
+import java.util.*;
 
 @SuperBuilder
 @ToString
@@ -50,6 +47,7 @@ import jakarta.validation.constraints.NotNull;
                 "- linux/amd64",
                 "tags:",
                 "- private-registry.io/unit-test:latest",
+                "protocol: HTTPS",
                 "buildArgs:",
                 "  APT_PACKAGES: curl",
                 "labels:",
@@ -63,6 +61,19 @@ import jakarta.validation.constraints.NotNull;
     }
 )
 public class Build extends Task implements RunnableTask<Build.Output>, NamespaceFilesInterface, InputFilesInterface {
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum Protocol {
+
+        HTTP, HTTPS;
+
+        @Override
+        public String toString() {
+            return super.name().toLowerCase(Locale.ROOT);
+        }
+    }
+
     @Schema(
         title = "The URI of your Docker host e.g. localhost"
     )
@@ -129,6 +140,13 @@ public class Build extends Task implements RunnableTask<Build.Output>, Namespace
     private NamespaceFiles namespaceFiles;
 
     private Object inputFiles;
+
+    @Schema(
+        title = "The protocol to use for pushing the image to the container registry (HTTP or HTTPS)."
+    )
+    @PluginProperty
+    @Builder.Default
+    private Protocol protocol = Protocol.HTTPS;
 
     @Override
     public Output run(RunContext runContext) throws Exception {
@@ -198,8 +216,16 @@ public class Build extends Task implements RunnableTask<Build.Output>, Namespace
                 .awaitImageId();
 
             if (this.push) {
-                for(String tag : tags){
-                    PushResponseItemCallback resultPush = dockerClient.pushImageCmd(tag)
+                for (String tag : tags) {
+                    String registry = this.credentials.getRegistry();
+                    String protocol = this.protocol.toString();
+                    if (!protocol.equals("http") && !protocol.equals("https")) {
+                        throw new IllegalArgumentException("Invalid protocol: " + protocol + ". Only HTTP and HTTPS are supported.");
+                    }
+
+                    String fullTag = tag.contains("://") ? tag : protocol + "://" + tag;
+
+                    PushResponseItemCallback resultPush = dockerClient.pushImageCmd(fullTag)
                         .exec(new PushResponseItemCallback(runContext));
 
                     resultPush.awaitCompletion();

--- a/src/main/java/io/kestra/plugin/docker/Build.java
+++ b/src/main/java/io/kestra/plugin/docker/Build.java
@@ -217,11 +217,7 @@ public class Build extends Task implements RunnableTask<Build.Output>, Namespace
 
             if (this.push) {
                 for (String tag : tags) {
-                    String registry = this.credentials.getRegistry();
                     String protocol = this.protocol.toString();
-                    if (!protocol.equals("http") && !protocol.equals("https")) {
-                        throw new IllegalArgumentException("Invalid protocol: " + protocol + ". Only HTTP and HTTPS are supported.");
-                    }
 
                     String fullTag = tag.contains("://") ? tag : protocol + "://" + tag;
 

--- a/src/test/java/io/kestra/plugin/docker/BuildTest.java
+++ b/src/test/java/io/kestra/plugin/docker/BuildTest.java
@@ -64,6 +64,7 @@ class BuildTest {
             .buildArgs(Map.of("APT_PACKAGES", "curl"))
             .labels(Map.of("unit-test", "true"))
             .tags(Set.of("unit-test"))
+            .protocol(Build.Protocol.HTTP)
             .dockerfile(path.getFileName().toString())
             .build();
 


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->
- Added property which specifies what internet protocol should be used for docker push. By ticket: #32 