### PR TITLE
fix: enforce registry name in docker image to avoid 404

### DIFF
--- a/.github/setup-unit.sh
+++ b/.github/setup-unit.sh
@@ -1,0 +1,23 @@
+#Generate credentials
+mkdir auth
+docker run --rm \
+    --entrypoint htpasswd \
+    registry:2.7.0 -Bbn testuser testpassword > auth/htpasswd
+
+#Generate private docker registry
+docker run -d \
+    -p 5000:5000 \
+    --name plugin-docker-registry \
+    -v "$(pwd)"/auth:/auth \
+    -e "REGISTRY_AUTH=htpasswd" \
+    -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
+    -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
+    registry:2.7.0
+
+#Pull image, tag it, then push it to private registry
+docker pull ubuntu
+docker login localhost:5000 -u testuser -p testpassword
+docker tag ubuntu localhost:5000/ubuntu:unit-test
+docker push localhost:5000/ubuntu:unit-test
+
+docker logout localhost:5000

--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ dependencies {
 
     // test
     testImplementation "org.junit.jupiter:junit-jupiter-engine"
+    testImplementation "org.junit.jupiter:junit-jupiter-params"
     testImplementation "org.hamcrest:hamcrest"
     testImplementation "org.hamcrest:hamcrest-library"
 }

--- a/src/test/java/io/kestra/plugin/docker/AbstractDockerHelper.java
+++ b/src/test/java/io/kestra/plugin/docker/AbstractDockerHelper.java
@@ -1,0 +1,19 @@
+package io.kestra.plugin.docker;
+
+public class AbstractDockerHelper {
+    public String getPassword() {
+        return "testpassword";
+    }
+
+    public String getUsername() {
+        return "testuser";
+    }
+
+    public String getRegistry() {
+        return "localhost:5000";
+    }
+
+    public String getPrivateImage() {
+        return "ubuntu:unit-test";
+    }
+}

--- a/src/test/java/io/kestra/plugin/docker/RunTest.java
+++ b/src/test/java/io/kestra/plugin/docker/RunTest.java
@@ -4,20 +4,25 @@ import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.RetryUtils;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.plugin.scripts.runner.docker.Credentials;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
-class RunTest {
+class RunTest extends AbstractDockerHelper {
     @Inject
     RunContextFactory runContextFactory;
 
@@ -35,5 +40,49 @@ class RunTest {
 
         assertThat(output, notNullValue());
         assertThat(output.getExitCode(), is(0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void run_pullImageFromPrivateRepo_correctCredentials(boolean useRegistry) throws Exception {
+        Run run = Run.builder()
+            .id(Run.class.getSimpleName())
+            .type(Run.class.getName())
+            .containerImage(Property.of(
+                useRegistry ? getPrivateImage() : getRegistry() + "/" + getPrivateImage()
+            ))
+            .credentials(Credentials.builder()
+                .username(Property.of(getUsername()))
+                .password(Property.of(getPassword()))
+                .registry(Property.of(getRegistry()))
+                .build())
+            .commands(Property.of(List.of("echo", "here")))
+            .build();
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, run, ImmutableMap.of());
+
+        ScriptOutput output = run.run(runContext);
+
+        assertThat(output, notNullValue());
+        assertThat(output.getExitCode(), is(0));
+    }
+
+    @Test
+    void run_pullImageFromPrivateRepo_incorrectCredentials() {
+        Run run = Run.builder()
+            .id(Run.class.getSimpleName())
+            .type(Run.class.getName())
+            .containerImage(Property.of(getPrivateImage()))
+            .credentials(Credentials.builder()
+                .username(Property.of(getUsername()))
+                .password(Property.of("incorrectPassword"))
+                .registry(Property.of(getRegistry()))
+                .build())
+            .commands(Property.of(List.of("echo", "here")))
+            .build();
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, run, ImmutableMap.of());
+
+
+        RetryUtils.RetryFailed exception = assertThrows(RetryUtils.RetryFailed.class, () -> run.run(runContext));
+        assertThat(exception.getCause().getMessage(), is("Status 500: {\"message\":\"unauthorized: authentication required\"}\n"));
     }
 }


### PR DESCRIPTION
Docker API parse image name to get registry, repo, image and tag. If registry is not present for a private registry the registry will be set to Docker hub
#50
