### PR TITLE
feat(build): add target parameter for multi-stage Dockerfile builds

### DIFF
--- a/src/main/java/io/kestra/plugin/docker/Build.java
+++ b/src/main/java/io/kestra/plugin/docker/Build.java
@@ -205,6 +205,13 @@ public class Build extends AbstractDocker implements RunnableTask<Build.Output>,
     @PluginProperty(group = "advanced")
     protected Property<Map<String, String>> labels;
 
+    @Schema(
+        title = "Target build stage",
+        description = "Name of the build stage to stop at in a multi-stage Dockerfile; equivalent to `--target`."
+    )
+    @PluginProperty(group = "advanced")
+    private Property<String> target;
+
     @PluginProperty(group = "source")
     private NamespaceFiles namespaceFiles;
 
@@ -274,6 +281,8 @@ public class Build extends AbstractDocker implements RunnableTask<Build.Output>,
             if (!renderedLabel.isEmpty()) {
                 buildImageCmd.withLabels(renderedLabel);
             }
+
+            runContext.render(this.target).as(String.class).ifPresent(buildImageCmd::withTarget);
 
             String imageId = buildImageCmd
                 .exec(new BuildImageResultCallback(runContext))

--- a/src/test/java/io/kestra/plugin/docker/BuildTest.java
+++ b/src/test/java/io/kestra/plugin/docker/BuildTest.java
@@ -49,6 +49,28 @@ class BuildTest {
     }
 
     @Test
+    void target() throws Exception {
+        Build task = Build.builder()
+            .id("unit-test")
+            .type(Build.class.getName())
+            .tags(Property.ofValue(List.of("unit-test-target")))
+            .target(Property.ofValue("base"))
+            .dockerfile(Property.ofValue("""
+                    FROM ubuntu AS base
+                    RUN echo "base stage"
+
+                    FROM base AS final
+                    RUN exit 1
+                """))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        Build.Output run = task.run(runContext);
+        assertThat(run.getImageId(), notNullValue());
+    }
+
+    @Test
     void local() throws Exception {
         RunContext runContext = runContextFactory.of();
 


### PR DESCRIPTION
## Summary

- Adds a `target` property to the `Build` task, mapping to Docker's `--target` flag
- Allows stopping the build at a specific named stage in a multi-stage Dockerfile
- Rendered via `runContext` and passed to `BuildImageCmd.withTarget(...)` only when set

## Test plan

- [ ] `BuildTest#target()` — uses a two-stage Dockerfile where the `final` stage runs `exit 1`; a successful build with a non-null image ID confirms the daemon stopped at the `base` stage