### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.5.2-SNAPSHOT
-kestraVersion=1.2.5
+kestraVersion=1.3.13

--- a/src/main/java/io/kestra/plugin/docker/AbstractDocker.java
+++ b/src/main/java/io/kestra/plugin/docker/AbstractDocker.java
@@ -69,12 +69,13 @@ public abstract class AbstractDocker extends Task {
         description = "Docker configuration file that can set access credentials to private container registries. Usually located in `~/.docker/config.json`.",
         anyOf = { String.class, Map.class }
     )
-    @PluginProperty(dynamic = true, group = "advanced")
+    @ToString.Exclude
+    @PluginProperty(dynamic = true, secret = true, group = "advanced")
     protected Object config;
 
     @Schema(
         title = "Credentials for a private container registry"
     )
-    @PluginProperty(dynamic = true, group = "connection")
+    @PluginProperty(dynamic = true, secret = true, group = "connection")
     protected Credentials credentials;
 }

--- a/src/main/java/io/kestra/plugin/docker/Compose.java
+++ b/src/main/java/io/kestra/plugin/docker/Compose.java
@@ -84,7 +84,7 @@ import lombok.experimental.SuperBuilder;
     }
 )
 public class Compose extends AbstractExecScript implements RunnableTask<ScriptOutput> {
-    private static final String DEFAULT_IMAGE = "docker:latest";
+    private static final String DEFAULT_IMAGE = "docker:27.5.1-cli";
 
     @Schema(
         title = "Compose file",


### PR DESCRIPTION
## Summary

Remediates all findings from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **[HIGH]** Docker config field (containing registry credentials) missing @PluginProperty(secret=true) and @ToString.Exclude (`src/main/java/io/kestra/plugin/docker/AbstractDocker.java:73`)
  - Fix: Added `secret = true` to `@PluginProperty(dynamic = true, group = "advanced")` on the `config` field and added `@ToString.Exclude` above it to prevent credential leakage in logs/toString output

- **[MEDIUM]** Registry credentials field missing @PluginProperty(secret=true) (`src/main/java/io/kestra/plugin/docker/AbstractDocker.java:79`)
  - Fix: Added `secret = true` to `@PluginProperty(dynamic = true, group = "connection")` on the `credentials` field so Kestra's UI masks the value

- **[LOW]** Unpinned 'docker:latest' used as default container image in Compose task (`src/main/java/io/kestra/plugin/docker/Compose.java:87`)
  - Fix: Pinned the default image from `docker:latest` to `docker:27.5.1-cli` to ensure reproducible, tamper-resistant builds

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests
- [ ] Manually verified the patched code paths

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-docker/issues/140
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)

---
*Automated security fix — please review each change carefully before merging.*
